### PR TITLE
added extended wrapper script and install instructions for linux

### DIFF
--- a/aliview-linux/aliview
+++ b/aliview-linux/aliview
@@ -93,7 +93,7 @@ shift $((OPTIND-1))
 ## then always use this jar - otherwise confusing
 progdir=$(dirname $0)
 if [ ! -f "$progdir/$jarfile" ]; then
-	progdir="$defprogdir"
+    progdir="$defprogdir"
     aliview="$progdir/$jarfile"
     if [ ! -x "$aliview" ] ; then
         echo "$0: Error: Cannot find \'$progdir/$jarfile\'"

--- a/aliview-linux/aliview
+++ b/aliview-linux/aliview
@@ -1,13 +1,129 @@
 #!/bin/bash
 
-# set current directory default
-DIRECTORY_OF_PROGRAM=$(dirname $0)
+set -euo pipefail
 
-# check if not in local then always use this jar - otherwise confusing
-if [ ! -f $DIRECTORY_OF_PROGRAM/aliview.jar ]; then
-	DIRECTORY_OF_PROGRAM=/usr/share/aliview
+function show_help () {
+cat <<HEREDOC
+File:
+
+    `basename $0` - Launcher script for aliview.jar
+
+Version:
+
+    Wrapper script version 29 Jan 2018
+    (to see aliview.jar version, use the '-v' option)
+
+By:
+
+    Anders.Larsson [at] icm.uu.se
+
+Description:
+
+    AliView: a fast and lightweight alignment viewer
+    and editor for large data sets.
+    Citation: Larsson, A. (2014). Bioinformatics30(22): 3276-3278.
+    http://dx.doi.org/10.1093/bioinformatics/btu531
+
+    See http://ormbunkar.se/aliview for documentation
+    and downloads.
+
+    Source: https://github.com/AliView/AliView
+
+Options:
+
+    -?, -h    -- show this help
+    -d        -- show debug info in terminal
+    -v        -- show aliview.jar version
+    -x <size> -- set max mem size for java
+
+Usage:
+
+    `basename $0` infile
+    `basename $0` infile1 infile2
+    `basename $0` -x2048M infile
+    `basename $0` -d infile
+    `basename $0` -v
+    `basename $0` -h
+
+HEREDOC
+}
+
+jarfile="aliview.jar"
+defprogdir="/usr/share/aliview"
+minjavamem="512M"
+maxjavamem="1024M"
+debug=0
+version=0
+
+## Check java
+if type -p java &>/dev/null; then
+    myjava=java
+elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+    myjava="$JAVA_HOME/bin/java"
+else
+    "Error: Cannot locate java"
+    exit 1
 fi
 
-# A correct wrapper script should pass all its arguments on as ${1+"$@"},
-# with regards to being able to handle embedded spaces properly. 
-java -Xmx1024M -Xms512M -jar $DIRECTORY_OF_PROGRAM/aliview.jar ${1+"$@"}
+## Check args 
+while getopts "h?vdx:" opt; do
+    case "$opt" in
+        h|\? )
+            show_help
+            exit 0
+            ;;
+        d )
+            debug=1
+            ;;
+        v )
+            version=1
+            ;;
+        x )
+            maxjavamem=$OPTARG
+            ;;
+        * ) echo "Unrecognized argument. use '-h' for usage information."
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+## Set current directory default, and check if not in local
+## then always use this jar - otherwise confusing
+progdir=$(dirname $0)
+if [ ! -f "$progdir/$jarfile" ]; then
+	progdir="$defprogdir"
+    aliview="$progdir/$jarfile"
+    if [ ! -x "$aliview" ] ; then
+        echo "$0: Error: Cannot find \'$progdir/$jarfile\'"
+        echo "This script is just a wrapper for $jarfile."
+        echo "See the aliview documentation for more information."
+        exit 1
+    fi
+fi
+
+## Try to get aliview version (experimental)
+if [ "$version" -eq 1 ]; then
+    nr=$(java -Djava.awt.headless=true -jar $aliview | grep -m1 'version' | awk '{print $NF}')
+    echo "$jarfile v.$nr"
+    exit 0
+fi
+
+## Launch aliview on all input
+if [ $# -eq 0 ]; then 
+    if [ "$debug" -eq 0 ]; then
+        $myjava -Xmx$maxjavamem -Xms$minjavamem -jar $aliview &> /dev/null &
+    else
+        $myjava -Xmx$maxjavamem -Xms$minjavamem -jar $aliview
+    fi
+else
+    for fil in "$@" ; do
+        if [ "$debug" -eq 0 ]; then
+            $myjava -Xmx$maxjavamem -Xms$minjavamem -jar $aliview "$fil" &> /dev/null &
+        else
+            $myjava -Xmx$maxjavamem -Xms$minjavamem -jar $aliview "$fil" &
+        fi
+    done
+fi
+

--- a/aliview-linux/install.readme.txt
+++ b/aliview-linux/install.readme.txt
@@ -2,7 +2,7 @@ Install:
 
 ---------- SIMPLEST ------------
 
-download and run the installer:
+download the installer from http://ormbunkar.se/downloads/linux and run:
 
 aliview.install.run
 
@@ -21,10 +21,40 @@ aliview (this is a sh-script that will execute java -jar aliview.jar)
 
 -----*** ALTERNATIVE (as non super-user) ***-----
 
-1. Download the archive aliview.tgz and extract it into a folder of your choice
+1. Download the archive aliview.tgz from http://ormbunkar.se/aliview/downloads/linux/ and extract it into a folder of your choice
 2. Run program from this folder by issuing command ./aliview from the terminal
    (this is a sh-script that will execute command java -jar aliview.jar)
 
 NOTE: If you are running Linux, consider upgrading to Java 8, there is a significant improvement in drawing speed
 since it is using Linux built in XRender. 
 Installation is very simple (1 minute) - http://ormbunkar.se/aliview/#java8install
+
+-----INSTALL FROM SOURCE -----
+
+Procedure below requires root (`sudo`) access.
+Tested on 64 bit Xubuntu 17.10 with Oracle java
+version 1.8.0_72, and Apache Maven v.3.5.0.
+
+1. Install Oracle Java 8
+
+        sudo add-apt-repository ppa:webupd8team/java
+        sudo apt update
+        sudo apt install oracle-java8-installer
+
+2. Install Apache Maven
+
+        sudo apt install maven
+
+3. Install makeself
+
+        sudo apt install makeself
+
+4. Install AliView, skip the MS Windows part
+
+        git clone https://github.com/AliView/AliView.git
+        cd AliView
+        mvn clean compile install package | tee mvn.build.log
+        bash <(sed -e '/WINDOWS/,$d' package.sh)
+        cd target/linux-version-*
+        sudo ./aliview.install.run
+


### PR DESCRIPTION
Added some command-line options for the wrapper script `aliview` functional on Linux (tested on bash v.4.4.12). The script now handles flags (short version only!) for help, version, debug, and an option to increase max heap size for java. Furthermore, the script should be able to handle multiple input files as such: `aliview *.fas`. Should obviously be tested by others.

An attempt was also done to include an example of a complete install procedure for debian-based (*buntu) Linux systems. This was added to the file `aliview-linux/install.readme.txt`
