### PR TITLE
set aliview var for non-default progdir

### DIFF
--- a/aliview-linux/aliview
+++ b/aliview-linux/aliview
@@ -110,7 +110,8 @@ shift $((OPTIND-1))
 ## then always use this jar - otherwise confusing
 absolute_file="$(resolve_links $0)"
 progdir=$(dirname $absolute_file)
-if [ ! -f "$progdir/$jarfile" ]; then
+aliview="$progdir/$jarfile"
+if [ ! -f "$aliview" ]; then
     progdir="$defprogdir"
     aliview="$progdir/$jarfile"
     if [ ! -x "$aliview" ] ; then


### PR DESCRIPTION
The current linux startup does not set `$aliview` by default, but only inside the `if` clause that checks if `aliview.jar` has been moved to a default location. If, however, the .jar file hasn't been moved, the script crashes with an error.