### PR TITLE
Translate codons with ambiguities when possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>AliView</groupId>
   <artifactId>AliView</artifactId>
   <packaging>jar</packaging>
-  <version>1.30</version>
+  <version>1.30+IUPAC</version>
   <name>AliView</name>
   <url>https://maven.apache.org</url>
   <properties>

--- a/src/main/java/aliview/AminoAcid.java
+++ b/src/main/java/aliview/AminoAcid.java
@@ -115,6 +115,87 @@ public class AminoAcid {
 
 	public static AminoAcid getAminoAcidFromCodon(byte[] codon, GeneticCode geneticCode) {
 
+		// if(codon == null || codon.length <3){
+		// 	return AminoAcid.GAP;
+		// }
+
+		// int baseVal0 = NucleotideUtilities.baseValFromChar((char)codon[0]);
+		// int baseVal1 = NucleotideUtilities.baseValFromChar((char)codon[1]);
+		// int baseVal2 = NucleotideUtilities.baseValFromChar((char)codon[2]);
+
+		// int position1Val;
+		// if(baseVal0 == NucleotideUtilities.T){
+		// 	position1Val = 0;
+		// }else if(baseVal0 == NucleotideUtilities.C){
+		// 	position1Val = 1;
+		// }else if(baseVal0 == NucleotideUtilities.A){
+		// 	position1Val = 2;
+		// }else if(baseVal0 == NucleotideUtilities.G){
+		// 	position1Val = 3;
+		// }
+		// else{
+		// 	position1Val = -1;
+		// }
+
+		// int position2Val;
+		// if(baseVal1 == NucleotideUtilities.T){
+		// 	position2Val = 0;
+		// }else if(baseVal1 == NucleotideUtilities.C){
+		// 	position2Val = 1;
+		// }else if(baseVal1 == NucleotideUtilities.A){
+		// 	position2Val = 2;
+		// }else if(baseVal1 == NucleotideUtilities.G){
+		// 	position2Val = 3;
+		// }
+		// else{
+		// 	position2Val = -1;
+		// }
+
+		// int position3Val;
+		// if(baseVal2 == NucleotideUtilities.T){
+		// 	position3Val = 0;
+		// }else if(baseVal2 == NucleotideUtilities.C){
+		// 	position3Val = 1;
+		// }else if(baseVal2 == NucleotideUtilities.A){
+		// 	position3Val = 2;
+		// }else if(baseVal2 == NucleotideUtilities.G){
+		// 	position3Val = 3;
+		// }
+		// else{
+		// 	position3Val = -1;
+		// }
+
+		// // Set default
+		// AminoAcid acid = X;
+
+		// if(position1Val == -1 || position2Val == -1 || position3Val == -1){
+		// 	acid = AminoAcid.X;
+		// }
+		// else{
+		// 	int acidVal = position1Val * 16 + position2Val * 4 + position3Val;
+		// 	acid = geneticCode.acidTranslation[acidVal];
+		// }
+
+		// if(baseVal0 == NucleotideUtilities.GAP && baseVal1 == NucleotideUtilities.GAP && baseVal2 == NucleotideUtilities.GAP){
+		// 	acid = AminoAcid.GAP;
+		// }
+
+
+		// /*
+		// if(baseVal0 == NucleotideUtilities.UNKNOWN || baseVal1 == NucleotideUtilities.UNKNOWN || baseVal2 == NucleotideUtilities.UNKNOWN){
+		// 	acid = AminoAcid.X;
+		// }
+		//  */
+
+		// return acid;	
+		return getAminoAcidFromIUPACCodon(codon, geneticCode);
+	}
+
+	public static AminoAcid getAminoAcidFromIUPACCodon(byte[] codon) {
+		return getAminoAcidFromIUPACCodon(codon, GeneticCode.DEFAULT);
+	}
+	
+	public static AminoAcid getAminoAcidFromIUPACCodon(byte[] codon, GeneticCode geneticCode) {
 		if(codon == null || codon.length <3){
 			return AminoAcid.GAP;
 		}
@@ -123,71 +204,12 @@ public class AminoAcid {
 		int baseVal1 = NucleotideUtilities.baseValFromChar((char)codon[1]);
 		int baseVal2 = NucleotideUtilities.baseValFromChar((char)codon[2]);
 
-		int position1Val;
-		if(baseVal0 == NucleotideUtilities.T){
-			position1Val = 0;
-		}else if(baseVal0 == NucleotideUtilities.C){
-			position1Val = 1;
-		}else if(baseVal0 == NucleotideUtilities.A){
-			position1Val = 2;
-		}else if(baseVal0 == NucleotideUtilities.G){
-			position1Val = 3;
-		}
-		else{
-			position1Val = -1;
+		if (baseVal0 == NucleotideUtilities.UNKNOWN || baseVal1 == NucleotideUtilities.UNKNOWN || baseVal2 == NucleotideUtilities.UNKNOWN) {
+			return AminoAcid.X;
 		}
 
-		int position2Val;
-		if(baseVal1 == NucleotideUtilities.T){
-			position2Val = 0;
-		}else if(baseVal1 == NucleotideUtilities.C){
-			position2Val = 1;
-		}else if(baseVal1 == NucleotideUtilities.A){
-			position2Val = 2;
-		}else if(baseVal1 == NucleotideUtilities.G){
-			position2Val = 3;
-		}
-		else{
-			position2Val = -1;
-		}
-
-		int position3Val;
-		if(baseVal2 == NucleotideUtilities.T){
-			position3Val = 0;
-		}else if(baseVal2 == NucleotideUtilities.C){
-			position3Val = 1;
-		}else if(baseVal2 == NucleotideUtilities.A){
-			position3Val = 2;
-		}else if(baseVal2 == NucleotideUtilities.G){
-			position3Val = 3;
-		}
-		else{
-			position3Val = -1;
-		}
-
-		// Set default
-		AminoAcid acid = X;
-
-		if(position1Val == -1 || position2Val == -1 || position3Val == -1){
-			acid = AminoAcid.X;
-		}
-		else{
-			int acidVal = position1Val * 16 + position2Val * 4 + position3Val;
-			acid = geneticCode.acidTranslation[acidVal];
-		}
-
-		if(baseVal0 == NucleotideUtilities.GAP && baseVal1 == NucleotideUtilities.GAP && baseVal2 == NucleotideUtilities.GAP){
-			acid = AminoAcid.GAP;
-		}
-
-
-		/*
-		if(baseVal0 == NucleotideUtilities.UNKNOWN || baseVal1 == NucleotideUtilities.UNKNOWN || baseVal2 == NucleotideUtilities.UNKNOWN){
-			acid = AminoAcid.X;
-		}
-		 */
-
-		return acid;	
+		int iupacVal = baseVal0 << 8 | baseVal1 << 4 | baseVal2;
+		return geneticCode.iupacAcidTranslation[iupacVal];
 	}
 
 	public byte getCodeByteVal() {
@@ -196,6 +218,14 @@ public class AminoAcid {
 
 	public static final AminoAcid getAminoAcidFromByte(byte base){
 		return getAminoAcidFromChar((char)base);
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getThreeLetterName() {
+		return threeLeterName;
 	}
 
 	public static final AminoAcid getAminoAcidFromChar(char base){

--- a/src/main/java/aliview/GeneticCode.java
+++ b/src/main/java/aliview/GeneticCode.java
@@ -1,5 +1,8 @@
 package aliview;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 
 public final class GeneticCode {
 
@@ -10,6 +13,8 @@ public final class GeneticCode {
 	public String codeString;
 	private String startCodon;
 
+	private final static int IUPAC_CODE_STATES = 4192;
+	public final AminoAcid[] iupacAcidTranslation = new AminoAcid[IUPAC_CODE_STATES];
 
 	// Genetic code information: http://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi
 	//
@@ -50,6 +55,83 @@ public final class GeneticCode {
 		this.startCodon = startCodon;
 		for(int n = 0; n < CODE_STATES; n++){
 			acidTranslation[n] = AminoAcid.getAminoAcidFromChar(codeString.charAt(n));
+		}
+		// initialize iupacAcidTranslation to UNKNOWN (except for 0, which is GAP)
+		iupacAcidTranslation[0] = AminoAcid.GAP;
+		for(int n = 1; n < IUPAC_CODE_STATES; n++){
+			iupacAcidTranslation[n] = AminoAcid.X;
+		}
+		// build a map of which codons code for each amino acid
+		HashMap<AminoAcid, ArrayList<Integer>> acidToCodon = new HashMap<AminoAcid, ArrayList<Integer>>();
+		for(int n = 0; n < CODE_STATES; n++){
+			AminoAcid acid = acidTranslation[n];
+			if(!acidToCodon.containsKey(acid)){
+				acidToCodon.put(acid, new ArrayList<Integer>());
+			}
+			acidToCodon.get(acid).add(n);
+		}
+
+		// codons use 2-bit encoding, (T = 0, C = 1, A = 2, G = 3)
+		// everything else uses 4-bit encoding (T = 8, C = 2, A = 1, G = 4))
+		int[] indexToBase = {8,2,1,4};
+
+        // now fill in the other non-UNKNOWN codons
+
+		// codons which code for the current amino acid, and which have a base which matches the current ambiguity at position2
+		ArrayList<Integer> position2Codons = new ArrayList<Integer>();
+		// codons which code for the current amino acid, and which have a base which matches the current ambiguity at position1
+		// (and position2)
+		ArrayList<Integer> position1Codons = new ArrayList<Integer>();
+
+		for (AminoAcid aa : acidToCodon.keySet()){
+			ArrayList<Integer> codons = acidToCodon.get(aa);
+			// start with position 2, it is the most conserved, so it will tend to fail early
+			for (int position2IUPAC = 1; position2IUPAC < 16; position2IUPAC++){
+				position2Codons.clear();
+				int p2found = 0; // accumulate all bases at position2 which match position2IUPAC
+				for (Integer codon : codons) {
+					// get the base at position 2
+					int base2 = indexToBase[(codon & 0b001100) >> 2];
+					// if the base matches the current ambiguity at position 2, add the codon to the list
+					if ((base2 & position2IUPAC) == base2) {
+						position2Codons.add(codon);
+						p2found |= base2;
+					}
+				}
+				// if we found all of the bases required to match position2IUPAC, then we can continue
+				if (p2found != position2IUPAC) {
+					continue;
+				}
+				for (int position1IUPAC = 1; position1IUPAC < 16; position1IUPAC++){
+					position1Codons.clear();
+					int p1found = 0; // accumulate all bases at position1 which match position1IUPAC
+					for (Integer codon : position2Codons) {
+						int base1 = indexToBase[(codon & 0b110000) >> 4];
+						if ((base1 & position1IUPAC) == base1) {
+							position1Codons.add(codon);
+							p1found |= base1;
+						}
+					}
+					if (p1found != position1IUPAC) {
+						continue;
+					}
+					for (int position3IUPAC = 1; position3IUPAC < 16; position3IUPAC++){
+						int p3found = 0;
+						for (Integer codon : position1Codons) {
+							int base3 = indexToBase[(codon & 0b000011)];
+							if ((base3 & position3IUPAC) == base3) {
+								p3found |= base3;
+								if (p3found == position3IUPAC) {
+									// we have found all of the bases required to match position3IUPAC
+									// so we can add the codon to the iupacAcidTranslation and stop looking
+									iupacAcidTranslation[position3IUPAC + (position2IUPAC << 4) + (position1IUPAC << 8)] = aa;
+									break;
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Generates an extended translation table of size 4192 in the constructor of `GeneticCode`, which translates codons which may include IUPAC ambiguous bases. Codons containing ambiguities are translated to an amino acid when all possible realizations of the ambiguity would translate as the same amino acid, or otherwise as `X`.  Current behavior always translates a codon with an ambiguous base as `X`.

The extended translation table is calculated from the standard translation table during startup, and this seems to take negligible time.  In my test with a big-ish alignment (5000 seqs x 1800 columns) the GUI stays responsive.

As implemented here, this replaces the standard behavior (because `AminoAcid.getAminoAcidFromCodon()` calls the new `AminoAcid.getAminoAcidFromIUPACCodon()`) but in principle this could be a configurable option in the same way as "Ignore gaps while translating".  I did not do this yet because I personally will always want the new behavior.  :-)  However if you would prefer it to be implemented as an option and don't have time to do that yourself, then I could give it a shot.