### PR TITLE
Add dark themes

### DIFF
--- a/src/main/java/aliview/AliViewWindow.java
+++ b/src/main/java/aliview/AliViewWindow.java
@@ -2971,6 +2971,15 @@ public class AliViewWindow extends JFrame implements UndoControler, AlignmentLis
 		alignmentPane.setBackground(color);
 		alignmentPane.getRulerComponent().setBackground(color);
 		alignmentPane.getCharsetRulerComponent().setBackground(color);
+
+		// Adjust the foreground text color based on perceived brightness of the background
+		double luminance = 0.2126 * color.getRed() + 0.7152 * color.getGreen() + 0.0722 * color.getBlue();
+		Color fgColor = luminance < 128 ? new Color(220, 220, 220) : Color.BLACK;
+
+		sequenceJList.setForeground(fgColor);
+		alignmentPane.getRulerComponent().setForeground(fgColor);
+		alignmentPane.getCharsetRulerComponent().setForeground(fgColor);
+		listTopOffset.setForeground(fgColor);
 	}
 
 	public void setColorSchemeNucleotide(ColorScheme aScheme){
@@ -4575,7 +4584,6 @@ public class AliViewWindow extends JFrame implements UndoControler, AlignmentLis
 
 
 }
-
 
 
 

--- a/src/main/java/aliview/color/ColorSchemeFactory.java
+++ b/src/main/java/aliview/color/ColorSchemeFactory.java
@@ -9,20 +9,33 @@ public class ColorSchemeFactory {
 	private static ColorScheme DEFAULT_COLOR_SCHEME_FAST = new DefaultColorSchemeFast();
 	private static ColorScheme SEAVIEW_COLOR_SCHEME = new SeaViewColorScheme();
 	private static ColorScheme CLUSTAL_X_COLOR_SCHEME = new ClustalXColorScheme();
+	private static ColorScheme DARK_COLOR_SCHEME_BLOCKS = new DarkColorScheme();
+	private static ColorScheme DARK_COLOR_SCHEME_TEXT = new DarkColorSchemeText();
+	private static ColorScheme DARK_NEON = new DarkNeonColorScheme();
+	private static ColorScheme DARK_LIGHT_TEXT = new DarkLightTextColorScheme();
 	private static List<ColorScheme> nucleotideColorSchemes = new ArrayList<ColorScheme>();
 	private static List<ColorScheme> aaColorSchemes = new ArrayList<ColorScheme>();
 	private static List<ColorScheme> allColorSchemes = new ArrayList<ColorScheme>();
 	static{
+        nucleotideColorSchemes.clear(); // Clear default list
 		nucleotideColorSchemes.add(DEFAULT_COLOR_SCHEME);
 		nucleotideColorSchemes.add(DEFAULT_COLOR_SCHEME_FAST);
 		nucleotideColorSchemes.add(SEAVIEW_COLOR_SCHEME);	
+		nucleotideColorSchemes.add(DARK_NEON);
+        nucleotideColorSchemes.add(DARK_LIGHT_TEXT);
+		nucleotideColorSchemes.add(DARK_COLOR_SCHEME_TEXT);
 		aaColorSchemes.add(DEFAULT_COLOR_SCHEME);
 		aaColorSchemes.add(SEAVIEW_COLOR_SCHEME);
 		aaColorSchemes.add(CLUSTAL_X_COLOR_SCHEME);
+		aaColorSchemes.add(DARK_COLOR_SCHEME_BLOCKS);
+		aaColorSchemes.add(DARK_COLOR_SCHEME_TEXT);
 		allColorSchemes.add(DEFAULT_COLOR_SCHEME);
 		allColorSchemes.add(DEFAULT_COLOR_SCHEME_FAST);
 		allColorSchemes.add(SEAVIEW_COLOR_SCHEME);
 		allColorSchemes.add(CLUSTAL_X_COLOR_SCHEME);
+		allColorSchemes.add(DARK_NEON);
+        allColorSchemes.add(DARK_LIGHT_TEXT);
+		allColorSchemes.add(DARK_COLOR_SCHEME_TEXT);
 	}
 
 	public static ColorScheme getColorScheme(String name){	

--- a/src/main/java/aliview/color/DarkColorScheme.java
+++ b/src/main/java/aliview/color/DarkColorScheme.java
@@ -1,0 +1,88 @@
+package aliview.color;
+
+import java.awt.Color;
+import aliview.AminoAcid;
+import aliview.NucleotideUtilities;
+
+public class DarkColorScheme extends DefaultColorScheme {
+
+    public DarkColorScheme() {
+        super();
+        this.colorSchemeName = "Dark Blocks";
+        
+        Color GAP_BG = new Color(40, 40, 40);
+        Color FG_DEFAULT = new Color(220, 220, 220);
+        
+        baseBackgroundColor = new Color[64];
+        baseBackgroundColor[NucleotideUtilities.A] = new Color(0, 80, 0); 
+        baseBackgroundColor[NucleotideUtilities.C] = new Color(0, 0, 120);
+        baseBackgroundColor[NucleotideUtilities.G] = new Color(80, 80, 0); 
+        baseBackgroundColor[NucleotideUtilities.TU] = new Color(120, 0, 0); 
+        Color IUPAC_BG = new Color(60, 60, 60);
+        baseBackgroundColor[NucleotideUtilities.R] = IUPAC_BG;
+        baseBackgroundColor[NucleotideUtilities.Y] = IUPAC_BG;
+        baseBackgroundColor[NucleotideUtilities.M] = IUPAC_BG;
+        baseBackgroundColor[NucleotideUtilities.K] = IUPAC_BG;
+        baseBackgroundColor[NucleotideUtilities.W] = IUPAC_BG;
+        baseBackgroundColor[NucleotideUtilities.S] = IUPAC_BG;
+        baseBackgroundColor[NucleotideUtilities.B] = IUPAC_BG; 
+        baseBackgroundColor[NucleotideUtilities.D] = IUPAC_BG;
+        baseBackgroundColor[NucleotideUtilities.H] = IUPAC_BG;
+        baseBackgroundColor[NucleotideUtilities.V] = IUPAC_BG;
+        baseBackgroundColor[NucleotideUtilities.N] = IUPAC_BG; 
+        baseBackgroundColor[NucleotideUtilities.GAP] = GAP_BG;
+        baseBackgroundColor[NucleotideUtilities.UNKNOWN] = IUPAC_BG;
+        
+        baseForegroundColor = new Color[64];
+        for (int i = 0; i < 64; i++) baseForegroundColor[i] = FG_DEFAULT;
+        baseForegroundColor[NucleotideUtilities.GAP] = new Color(120, 120, 120);
+
+        baseSelectionBackgroundColor = new Color[64];
+        for (int i = 0; i < 64; i++) {
+            Color c = baseBackgroundColor[i];
+            if (c == null) c = GAP_BG;
+            baseSelectionBackgroundColor[i] = new Color(Math.min(255, c.getRed() + 50), Math.min(255, c.getGreen() + 50), Math.min(255, c.getBlue() + 50));
+        }
+        
+        baseSelectionForegroundColor = new Color[64];
+        for (int i = 0; i < 64; i++) baseSelectionForegroundColor[i] = Color.WHITE;
+
+        baseConsensusBackgroundColor = new Color(60, 60, 60);
+
+        // Amino Acids
+        aminoAcidBackgroundColor = new Color[255];
+        aminoAcidForegroundColor = new Color[255];
+        aminoAcidSelectionBackgroundColor = new Color[255];
+        aminoAcidSelectionForegroundColor = new Color[255];
+
+        for (int i = 0; i < 255; i++) {
+            aminoAcidBackgroundColor[i] = GAP_BG;
+            aminoAcidSelectionBackgroundColor[i] = new Color(80, 80, 80);
+            aminoAcidForegroundColor[i] = FG_DEFAULT;
+            aminoAcidSelectionForegroundColor[i] = Color.WHITE;
+        }
+
+        DefaultColorScheme def = new DefaultColorScheme();
+        for (AminoAcid acid : AminoAcid.GROUP_ALL) {
+            int i = acid.intVal;
+            Color origBg = def.getAminoAcidBackgroundColor(acid);
+            if (origBg == null) continue;
+            if (origBg.equals(Color.white) || origBg.equals(new Color(230,230,230))) {
+                aminoAcidBackgroundColor[i] = GAP_BG;
+            } else {
+                // Darken the original color for dark mode
+                aminoAcidBackgroundColor[i] = new Color(origBg.getRed()/2, origBg.getGreen()/2, origBg.getBlue()/2);
+            }
+            
+            Color c = aminoAcidBackgroundColor[i];
+            aminoAcidSelectionBackgroundColor[i] = new Color(
+                Math.min(255, c.getRed() + 50),
+                Math.min(255, c.getGreen() + 50),
+                Math.min(255, c.getBlue() + 50)
+            );
+        }
+        aminoAcidForegroundColor[AminoAcid.GAP.intVal] = new Color(120, 120, 120);
+        
+        aminoAcidConsensusBackgroundColor = new Color(60, 60, 60);
+    }
+}

--- a/src/main/java/aliview/color/DarkColorSchemeText.java
+++ b/src/main/java/aliview/color/DarkColorSchemeText.java
@@ -1,0 +1,70 @@
+package aliview.color;
+
+import java.awt.Color;
+import aliview.AminoAcid;
+import aliview.NucleotideUtilities;
+
+public class DarkColorSchemeText extends DefaultColorScheme {
+
+    public DarkColorSchemeText() {
+        super();
+        this.colorSchemeName = "Dark Text";
+        
+        Color BG = new Color(30, 30, 30);
+        Color BG_SELECTED = new Color(70, 70, 70);
+        
+        baseBackgroundColor = new Color[64];
+        baseSelectionBackgroundColor = new Color[64];
+        baseForegroundColor = new Color[64];
+        baseSelectionForegroundColor = new Color[64];
+
+        for (int i = 0; i < 64; i++) {
+            baseBackgroundColor[i] = BG;
+            baseSelectionBackgroundColor[i] = BG_SELECTED;
+            baseForegroundColor[i] = new Color(200, 200, 200);
+            baseSelectionForegroundColor[i] = Color.WHITE;
+        }
+
+        baseForegroundColor[NucleotideUtilities.A] = new Color(110, 240, 110); 
+        baseForegroundColor[NucleotideUtilities.C] = new Color(110, 170, 255); 
+        baseForegroundColor[NucleotideUtilities.G] = new Color(240, 200, 80);  
+        baseForegroundColor[NucleotideUtilities.TU] = new Color(255, 110, 110); 
+        
+        baseSelectionForegroundColor[NucleotideUtilities.A] = baseForegroundColor[NucleotideUtilities.A].brighter();
+        baseSelectionForegroundColor[NucleotideUtilities.C] = baseForegroundColor[NucleotideUtilities.C].brighter();
+        baseSelectionForegroundColor[NucleotideUtilities.G] = baseForegroundColor[NucleotideUtilities.G].brighter();
+        baseSelectionForegroundColor[NucleotideUtilities.TU] = baseForegroundColor[NucleotideUtilities.TU].brighter();
+
+        baseForegroundColor[NucleotideUtilities.GAP] = new Color(120, 120, 120);
+        baseSelectionForegroundColor[NucleotideUtilities.GAP] = new Color(170, 170, 170);
+
+        baseConsensusBackgroundColor = new Color(50, 50, 50);
+
+        // Amino Acids
+        aminoAcidBackgroundColor = new Color[255];
+        aminoAcidForegroundColor = new Color[255];
+        aminoAcidSelectionBackgroundColor = new Color[255];
+        aminoAcidSelectionForegroundColor = new Color[255];
+
+        for (int i = 0; i < 255; i++) {
+            aminoAcidBackgroundColor[i] = BG;
+            aminoAcidSelectionBackgroundColor[i] = BG_SELECTED;
+        }
+        
+        DefaultColorScheme def = new DefaultColorScheme();
+        for (AminoAcid acid : AminoAcid.GROUP_ALL) {
+            int i = acid.intVal;
+            Color origBg = def.getAminoAcidBackgroundColor(acid);
+            if (origBg != null && !origBg.equals(Color.white) && !origBg.equals(new Color(230, 230, 230))) {
+                aminoAcidForegroundColor[i] = origBg.brighter();
+                aminoAcidSelectionForegroundColor[i] = origBg.brighter().brighter();
+            } else {
+                aminoAcidForegroundColor[i] = new Color(200, 200, 200);
+                aminoAcidSelectionForegroundColor[i] = Color.WHITE;
+            }
+        }
+        aminoAcidForegroundColor[AminoAcid.GAP.intVal] = new Color(120, 120, 120);
+        aminoAcidSelectionForegroundColor[AminoAcid.GAP.intVal] = new Color(170, 170, 170);
+        aminoAcidConsensusBackgroundColor = new Color(50, 50, 50);
+    }
+}

--- a/src/main/java/aliview/color/DarkLightTextColorScheme.java
+++ b/src/main/java/aliview/color/DarkLightTextColorScheme.java
@@ -1,0 +1,33 @@
+package aliview.color;
+
+import java.awt.Color;
+import aliview.NucleotideUtilities;
+
+public class DarkLightTextColorScheme extends DarkColorScheme {
+    public DarkLightTextColorScheme() {
+        super();
+        this.colorSchemeName = "Dark with light text";
+
+        // --- Background Block Colors ---
+        baseBackgroundColor[NucleotideUtilities.A] = new Color(0, 128, 0);
+        baseBackgroundColor[NucleotideUtilities.C] = new Color(0, 0, 255);
+        baseBackgroundColor[NucleotideUtilities.G] = new Color(107, 99, 99);
+        baseBackgroundColor[NucleotideUtilities.TU] = new Color(199, 29, 77);
+
+        // --- Foreground Letter Colors (Light Text) ---
+        for(int i = 0; i < 64; i++) {
+            baseForegroundColor[i] = new Color(220, 220, 220); // Off-white
+        }
+        baseForegroundColor[NucleotideUtilities.GAP] = new Color(100, 100, 100);
+
+        // --- Custom Selection Logic for Light Text ---
+        for(int i = 0; i < 64; i++) {
+            if (baseBackgroundColor[i] != null) {
+                // Selection background becomes a bit more vivid
+                baseSelectionBackgroundColor[i] = baseBackgroundColor[i].brighter();
+                // Letters become pure white to "glow"
+                baseSelectionForegroundColor[i] = Color.WHITE;
+            }
+        }
+    }
+}

--- a/src/main/java/aliview/color/DarkNeonColorScheme.java
+++ b/src/main/java/aliview/color/DarkNeonColorScheme.java
@@ -1,0 +1,44 @@
+package aliview.color;
+
+import java.awt.Color;
+import aliview.NucleotideUtilities;
+
+public class DarkNeonColorScheme extends DarkColorScheme {
+    public DarkNeonColorScheme() {
+        super();
+        this.colorSchemeName = "Dark Neon";
+
+        // --- Background Block Colors ---
+        baseBackgroundColor[NucleotideUtilities.A] = new Color(32, 167, 102);
+        baseBackgroundColor[NucleotideUtilities.C] = new Color(0, 128, 255);
+        baseBackgroundColor[NucleotideUtilities.G] = new Color(107, 99, 99);
+        baseBackgroundColor[NucleotideUtilities.TU] = new Color(223, 32, 86);
+
+        // --- Foreground Letter Colors ---
+        baseForegroundColor[NucleotideUtilities.A] = new Color(0, 60, 0);
+        baseForegroundColor[NucleotideUtilities.C] = new Color(0, 0, 110);
+        baseForegroundColor[NucleotideUtilities.G] = new Color(45, 40, 40);
+        baseForegroundColor[NucleotideUtilities.TU] = new Color(90, 10, 30);
+        
+        // IUPAC Foreground
+        Color iupacFG = new Color(110, 0, 110);
+        baseForegroundColor[NucleotideUtilities.R] = iupacFG;
+        baseForegroundColor[NucleotideUtilities.Y] = iupacFG;
+        baseForegroundColor[NucleotideUtilities.M] = iupacFG;
+        baseForegroundColor[NucleotideUtilities.K] = iupacFG;
+        baseForegroundColor[NucleotideUtilities.W] = iupacFG;
+        baseForegroundColor[NucleotideUtilities.S] = iupacFG;
+        baseForegroundColor[NucleotideUtilities.N] = iupacFG;
+        baseForegroundColor[NucleotideUtilities.GAP] = new Color(80, 80, 80);
+
+        // --- Custom Selection Logic for Neon ---
+        for(int i = 0; i < 64; i++) {
+            if (baseBackgroundColor[i] != null) {
+                // Selection blocks are significantly brighter versions of the neon blocks
+                baseSelectionBackgroundColor[i] = baseBackgroundColor[i].brighter();
+                // Letters turn white when selected for high contrast
+                baseSelectionForegroundColor[i] = Color.WHITE;
+            }
+        }
+    }
+}

--- a/src/main/java/aliview/gui/pane/AlignmentPane.java
+++ b/src/main/java/aliview/gui/pane/AlignmentPane.java
@@ -1428,7 +1428,7 @@ public class AlignmentPane extends JPanel{
 
 
 						// draw tickmarks
-						g2d.setColor(Color.DARK_GRAY);
+						g2d.setColor(getForeground());
 						// make every 5 tickmarks a bit bigger
 						if(x % 5 == 4 && charWidth > 0.6){ // it has to be 4 and not 0 due to the fact that 1:st base har position 0 in matrix
 							// we are drawing not on a large scrollable ruler, but a window sized fixed pane we have to adjust with offsetDueToScrollPanePosition
@@ -1576,7 +1576,7 @@ public class AlignmentPane extends JPanel{
 				int countTicks = 0;
 
 				// Same color for everything
-				g2d.setColor(Color.DARK_GRAY);
+				g2d.setColor(getForeground());
 
 				// X Loop Start
 				for(int xSeq = (int)startPosSeq; xSeq < maxVisibleSeq; xSeq = xSeq + xStep){
@@ -1780,4 +1780,3 @@ public class AlignmentPane extends JPanel{
 	} // end CodonPosRuler class
 
 }
-


### PR DESCRIPTION
Addresses #96 and #130

This PR introduces a suite of "Dark Mode" color schemes to AliView. These themes are specifically optimized for dark backgrounds while maintaining legibility of both residue blocks and character text.

1. Nucleotide Themes:
- **Dark Neon**: High-contrast palette with dark characters "engraved" into vibrant neon blocks.
- **Dark with Light Text**: A balanced theme with forest/navy tones and off-white text.
- **Dark Text**: Minimalist dark background emphasizing character shapes over block colors.

2. Amino Acid Themes:
- **Dark Blocks**: A palette providing distinct colors for AA residues.
- **Dark Text**: Character-focused dark theme for protein sequences.

**Files changed**:
- `src/main/java/aliview/color/DarkColorScheme.java`: Base class for dark logic.
- `src/main/java/aliview/color/DarkNeonColorScheme.java`: Implementation of the Neon palette.
- `src/main/java/aliview/color/DarkLightTextColorScheme.java`: Implementation of the Light Text palette.
- `src/main/java/aliview/color/DarkColorSchemeText.java`: Implementation of dark theme without colored boxes.
- `src/main/java/aliview/color/ColorSchemeFactory.java`: Registration of new themes into the UI menus.
- `src/main/java/aliview/gui/pane/AlignmentPane.java`: Make tick colors adhere to overall theme. 
- `src/main/java/aliview/AliViewWindow.java`: Logic for sidebar foreground color flipping.

Preview of **Dark Neon**:
<img width="1280" height="794" alt="AliView_Dark_Neon" src="https://github.com/user-attachments/assets/a8c3387e-cbee-4667-9c36-0b18e0641265" />
